### PR TITLE
Feat/graceful failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ go.work.sum
 
 # env file
 .env
+.idea
+dist

--- a/internal/handler/metrics.go
+++ b/internal/handler/metrics.go
@@ -13,41 +13,41 @@ func Metrics(c *gin.Context) {
 }
 
 func MetricsCPU(c *gin.Context) {
-	metrics, metricsErrs := metric.CollectCpuMetrics()
-	apiResponse := metric.ApiResponse{
-		Cpu:    metrics,
+	cpuMetrics, metricsErrs := metric.CollectCpuMetrics()
+
+	c.JSON(200, metric.ApiResponse{
+		Data:   cpuMetrics,
 		Errors: metricsErrs,
-	}
-	c.JSON(200, apiResponse)
+	})
 	return
 }
 
 func MetricsMemory(c *gin.Context) {
-	metrics, metricsErrs := metric.CollectMemoryMetrics()
-	apiResponse := metric.ApiResponse{
-		Memory: metrics,
+	memoryMetrics, metricsErrs := metric.CollectMemoryMetrics()
+
+	c.JSON(200, metric.ApiResponse{
+		Data:   memoryMetrics,
 		Errors: metricsErrs,
-	}
-	c.JSON(200, apiResponse)
+	})
 	return
 }
 
 func MetricsDisk(c *gin.Context) {
-	metrics, metricsErrs := metric.CollectDiskMetrics()
-	apiResponse := metric.ApiResponse{
-		Disk:   metrics,
+	diskMetrics, metricsErrs := metric.CollectDiskMetrics()
+
+	c.JSON(200, metric.ApiResponse{
+		Data:   diskMetrics,
 		Errors: metricsErrs,
-	}
-	c.JSON(200, apiResponse)
+	})
 	return
 }
 
 func MetricsHost(c *gin.Context) {
-	metrics, metricsErrs := metric.GetHostInformation()
-	apiResponse := metric.ApiResponse{
-		Host:   metrics,
+	hostMetrics, metricsErrs := metric.GetHostInformation()
+
+	c.JSON(200, metric.ApiResponse{
+		Data:   hostMetrics,
 		Errors: metricsErrs,
-	}
-	c.JSON(200, apiResponse)
+	})
 	return
 }

--- a/internal/handler/metrics.go
+++ b/internal/handler/metrics.go
@@ -6,57 +6,57 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func Metrics(c *gin.Context) {
-	metrics, metricsErr := metric.GetAllSystemMetrics()
-	if metricsErr != nil {
-		c.JSON(500, "Unable to get metrics")
-		return
-	}
+type HttpResponse struct {
+	Data   interface{} `json:"metrics"`
+	Errors []string
+}
 
-	c.JSON(200, metrics)
+func Metrics(c *gin.Context) {
+	metrics, metricsErrs := metric.GetAllSystemMetrics()
+	response := HttpResponse{
+		Data:   metrics,
+		Errors: metricsErrs,
+	}
+	c.JSON(200, response)
 	return
 }
 
 func MetricsCPU(c *gin.Context) {
-	metrics, metricsErr := metric.CollectCpuMetrics()
-	if metricsErr != nil {
-		c.JSON(500, "Unable to get metrics")
-		return
+	metrics, metricsErrs := metric.CollectCpuMetrics()
+	response := HttpResponse{
+		Data:   metrics,
+		Errors: metricsErrs,
 	}
-
-	c.JSON(200, metrics)
+	c.JSON(200, response)
 	return
 }
 
 func MetricsMemory(c *gin.Context) {
-	metrics, metricsErr := metric.CollectMemoryMetrics()
-	if metricsErr != nil {
-		c.JSON(500, "Unable to get metrics")
-		return
+	metrics, metricsErrs := metric.CollectMemoryMetrics()
+	response := HttpResponse{
+		Data:   metrics,
+		Errors: metricsErrs,
 	}
-
-	c.JSON(200, metrics)
+	c.JSON(200, response)
 	return
 }
 
 func MetricsDisk(c *gin.Context) {
-	metrics, metricsErr := metric.CollectDiskMetrics()
-	if metricsErr != nil {
-		c.JSON(500, "Unable to get metrics")
-		return
+	metrics, metricsErrs := metric.CollectDiskMetrics()
+	response := HttpResponse{
+		Data:   metrics,
+		Errors: metricsErrs,
 	}
-
-	c.JSON(200, metrics)
+	c.JSON(200, response)
 	return
 }
 
 func MetricsHost(c *gin.Context) {
-	metrics, metricsErr := metric.GetHostInformation()
-	if metricsErr != nil {
-		c.JSON(500, "Unable to get metrics")
-		return
+	metrics, metricsErrs := metric.GetHostInformation()
+	response := HttpResponse{
+		Data:   metrics,
+		Errors: metricsErrs,
 	}
-
-	c.JSON(200, metrics)
+	c.JSON(200, response)
 	return
 }

--- a/internal/handler/metrics.go
+++ b/internal/handler/metrics.go
@@ -6,57 +6,50 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type HttpResponse struct {
-	Data   interface{} `json:"metrics"`
-	Errors []string
-}
-
 func Metrics(c *gin.Context) {
-	metrics, metricsErrs := metric.GetAllSystemMetrics()
-	response := HttpResponse{
-		Data:   metrics,
-		Errors: metricsErrs,
-	}
-	c.JSON(200, response)
+	metrics := metric.GetAllSystemMetrics()
+	c.JSON(200, metrics)
 	return
 }
 
 func MetricsCPU(c *gin.Context) {
 	metrics, metricsErrs := metric.CollectCpuMetrics()
-	response := HttpResponse{
-		Data:   metrics,
+	apiResponse := metric.ApiResponse{
+		Cpu:    metrics,
 		Errors: metricsErrs,
 	}
-	c.JSON(200, response)
+	c.JSON(200, apiResponse)
 	return
 }
 
 func MetricsMemory(c *gin.Context) {
 	metrics, metricsErrs := metric.CollectMemoryMetrics()
-	response := HttpResponse{
-		Data:   metrics,
+	apiResponse := metric.ApiResponse{
+		Memory: metrics,
 		Errors: metricsErrs,
 	}
-	c.JSON(200, response)
+	c.JSON(200, apiResponse)
 	return
 }
 
 func MetricsDisk(c *gin.Context) {
 	metrics, metricsErrs := metric.CollectDiskMetrics()
-	response := HttpResponse{
-		Data:   metrics,
+	apiResponse := metric.ApiResponse{
+		Disk:   metrics,
 		Errors: metricsErrs,
 	}
-	c.JSON(200, response)
+	c.JSON(200, apiResponse)
+	return
 	return
 }
 
 func MetricsHost(c *gin.Context) {
 	metrics, metricsErrs := metric.GetHostInformation()
-	response := HttpResponse{
-		Data:   metrics,
+	apiResponse := metric.ApiResponse{
+		Host:   metrics,
 		Errors: metricsErrs,
 	}
-	c.JSON(200, response)
+	c.JSON(200, apiResponse)
+	return
 	return
 }

--- a/internal/handler/metrics.go
+++ b/internal/handler/metrics.go
@@ -40,7 +40,6 @@ func MetricsDisk(c *gin.Context) {
 	}
 	c.JSON(200, apiResponse)
 	return
-	return
 }
 
 func MetricsHost(c *gin.Context) {
@@ -50,6 +49,5 @@ func MetricsHost(c *gin.Context) {
 		Errors: metricsErrs,
 	}
 	c.JSON(200, apiResponse)
-	return
 	return
 }

--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -52,12 +52,12 @@ func WebSocket(c *gin.Context) {
 
 	// Streaming messages to the client
 	for {
-		metrics, metricsErr := metric.GetAllSystemMetrics()
-		if metricsErr != nil {
-			log.Printf("[FAIL] | Failed to get system metrics: %v", metricsErr)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get system metrics"})
-			return
-		}
+		metrics := metric.GetAllSystemMetrics()
+		//if metricsErr != nil {
+		//	log.Printf("[FAIL] | Failed to get system metrics: %v", metricsErr)
+		//	c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get system metrics"})
+		//	return
+		//}
 		data, dataErr := json.Marshal(metrics)
 		if dataErr != nil {
 			log.Printf("[FAIL] | Failed to marshal system metrics: %v", dataErr)

--- a/internal/metric/cpu.go
+++ b/internal/metric/cpu.go
@@ -2,40 +2,47 @@ package metric
 
 import (
 	"bluewave-uptime-agent/internal/sysfs"
-
 	"github.com/shirou/gopsutil/v4/cpu"
 )
 
-func CollectCpuMetrics() (*CpuData, error) {
+func CollectCpuMetrics() (*CpuData, []string) {
 	// Collect CPU Core Counts
 	cpuPhysicalCoreCount, cpuPhysicalErr := cpu.Counts(false)
 	cpuLogicalCoreCount, cpuLogicalErr := cpu.Counts(true)
 
+	var cpuErrors []string
 	if cpuPhysicalErr != nil {
-		return nil, cpuPhysicalErr
+		cpuErrors = append(cpuErrors, cpuPhysicalErr.Error())
+		cpuPhysicalCoreCount = 0
 	}
 
 	if cpuLogicalErr != nil {
-		return nil, cpuLogicalErr
+		cpuErrors = append(cpuErrors, cpuLogicalErr.Error())
+		cpuLogicalCoreCount = 0
 	}
 
 	// Collect CPU Information (Frequency, Model, etc)
 	cpuInformation, cpuInfoErr := cpu.Info()
-
+	var cpuFrequency float64
 	if cpuInfoErr != nil {
-		return nil, cpuInfoErr
+		cpuErrors = append(cpuErrors, cpuInfoErr.Error())
+		cpuFrequency = 0
+	} else {
+		cpuFrequency = cpuInformation[0].Mhz
 	}
 
 	// Collect CPU Usage
 	cpuTimes, cpuTimesErr := cpu.Times(false)
+	var cpuUsagePercent float64
 
 	if cpuTimesErr != nil {
-		return nil, cpuTimesErr
+		cpuErrors = append(cpuErrors, cpuTimesErr.Error())
+		cpuUsagePercent = 0
+	} else {
+		// Calculate CPU Usage Percentage
+		total := cpuTimes[0].User + cpuTimes[0].Nice + cpuTimes[0].System + cpuTimes[0].Idle + cpuTimes[0].Iowait + cpuTimes[0].Irq + cpuTimes[0].Softirq + cpuTimes[0].Steal + cpuTimes[0].Guest + cpuTimes[0].GuestNice
+		cpuUsagePercent = (total - (cpuTimes[0].Idle + cpuTimes[0].Iowait)) / total
 	}
-
-	// Calculate CPU Usage Percentage
-	total := cpuTimes[0].User + cpuTimes[0].Nice + cpuTimes[0].System + cpuTimes[0].Idle + cpuTimes[0].Iowait + cpuTimes[0].Irq + cpuTimes[0].Softirq + cpuTimes[0].Steal + cpuTimes[0].Guest + cpuTimes[0].GuestNice
-	cpuUsagePercent := (total - (cpuTimes[0].Idle + cpuTimes[0].Iowait)) / total
 
 	// Collect CPU Temperature from sysfs
 	// cpuTemp, cpuTempErr := sysfs.CpuTemperature()
@@ -45,18 +52,18 @@ func CollectCpuMetrics() (*CpuData, error) {
 	// }
 
 	cpuCurrentFrequency, cpuCurFreqErr := sysfs.CpuCurrentFrequency()
-
 	if cpuCurFreqErr != nil {
-		return nil, cpuCurFreqErr
+		cpuErrors = append(cpuErrors, cpuCurFreqErr.Error())
+		cpuCurrentFrequency = 0
 	}
 
 	return &CpuData{
 		PhysicalCore:     cpuPhysicalCoreCount,
 		LogicalCore:      cpuLogicalCoreCount,
-		Frequency:        cpuInformation[0].Mhz,
+		Frequency:        cpuFrequency,
 		CurrentFrequency: cpuCurrentFrequency,
 		Temperature:      nil,
 		FreePercent:      1 - cpuUsagePercent,
 		UsagePercent:     cpuUsagePercent,
-	}, nil
+	}, cpuErrors
 }

--- a/internal/metric/disk.go
+++ b/internal/metric/disk.go
@@ -4,12 +4,13 @@ import (
 	disk2 "github.com/shirou/gopsutil/v4/disk"
 )
 
-func CollectDiskMetrics() ([]*DiskData, error) {
+func CollectDiskMetrics() ([]*DiskData, []string) {
 	var diskData []*DiskData
+	var diskErrors []string
 	diskUsage, diskUsageErr := disk2.Usage("/")
 
 	if diskUsageErr != nil {
-		return nil, diskUsageErr
+		diskErrors = append(diskErrors, diskUsageErr.Error())
 	}
 
 	// diskMetrics, diskErr := disk1.Get()
@@ -30,7 +31,7 @@ func CollectDiskMetrics() ([]*DiskData, error) {
 		UsagePercent:    RoundFloatPtr(diskUsage.UsedPercent/100, 4),
 	})
 
-	return diskSlice, nil
+	return diskSlice, diskErrors
 }
 
 // func CollectDiskMetricsTrial() (map[string]disk2.IOCountersStat, error) {

--- a/internal/metric/disk.go
+++ b/internal/metric/disk.go
@@ -5,12 +5,22 @@ import (
 )
 
 func CollectDiskMetrics() ([]*DiskData, []string) {
+	defaultDiskData := []*DiskData{
+		{
+			ReadSpeedBytes:  nil,
+			WriteSpeedBytes: nil,
+			TotalBytes:      nil,
+			FreeBytes:       nil,
+			UsagePercent:    nil,
+		},
+	}
 	var diskData []*DiskData
 	var diskErrors []string
 	diskUsage, diskUsageErr := disk2.Usage("/")
 
 	if diskUsageErr != nil {
 		diskErrors = append(diskErrors, diskUsageErr.Error())
+		return defaultDiskData, diskErrors
 	}
 
 	// diskMetrics, diskErr := disk1.Get()

--- a/internal/metric/disk.go
+++ b/internal/metric/disk.go
@@ -4,7 +4,7 @@ import (
 	disk2 "github.com/shirou/gopsutil/v4/disk"
 )
 
-func CollectDiskMetrics() ([]*DiskData, []string) {
+func CollectDiskMetrics() (*[]*DiskData, []string) {
 	defaultDiskData := []*DiskData{
 		{
 			ReadSpeedBytes:  nil,
@@ -20,7 +20,7 @@ func CollectDiskMetrics() ([]*DiskData, []string) {
 
 	if diskUsageErr != nil {
 		diskErrors = append(diskErrors, diskUsageErr.Error())
-		return defaultDiskData, diskErrors
+		return &defaultDiskData, diskErrors
 	}
 
 	// diskMetrics, diskErr := disk1.Get()
@@ -41,7 +41,7 @@ func CollectDiskMetrics() ([]*DiskData, []string) {
 		UsagePercent:    RoundFloatPtr(diskUsage.UsedPercent/100, 4),
 	})
 
-	return diskSlice, diskErrors
+	return &diskSlice, diskErrors
 }
 
 // func CollectDiskMetricsTrial() (map[string]disk2.IOCountersStat, error) {

--- a/internal/metric/disk.go
+++ b/internal/metric/disk.go
@@ -4,7 +4,7 @@ import (
 	disk2 "github.com/shirou/gopsutil/v4/disk"
 )
 
-func CollectDiskMetrics() (*[]*DiskData, []CustomErr) {
+func CollectDiskMetrics() (MetricsSlice, []CustomErr) {
 	defaultDiskData := []*DiskData{
 		{
 			ReadSpeedBytes:  nil,
@@ -14,17 +14,15 @@ func CollectDiskMetrics() (*[]*DiskData, []CustomErr) {
 			UsagePercent:    nil,
 		},
 	}
-	var diskData []*DiskData
 	var diskErrors []CustomErr
 	diskUsage, diskUsageErr := disk2.Usage("/")
 
 	if diskUsageErr != nil {
-
 		diskErrors = append(diskErrors, CustomErr{
 			Metric: []string{"disk.usage_percent", "disk.total_bytes", "disk.free_bytes"},
 			Error:  diskUsageErr.Error(),
 		})
-		return &defaultDiskData, diskErrors
+		return MetricsSlice{defaultDiskData[0]}, diskErrors
 	}
 
 	// diskMetrics, diskErr := disk1.Get()
@@ -37,15 +35,16 @@ func CollectDiskMetrics() (*[]*DiskData, []CustomErr) {
 	// }
 
 	// var a uint64 = 2e+12
-	diskSlice := append(diskData, &DiskData{
+	var metricsSlice MetricsSlice
+
+	metricsSlice = append(metricsSlice, &DiskData{
 		ReadSpeedBytes:  nil, // TODO: Implement
 		WriteSpeedBytes: nil, // TODO: Implement
 		TotalBytes:      &diskUsage.Total,
 		FreeBytes:       &diskUsage.Free,
 		UsagePercent:    RoundFloatPtr(diskUsage.UsedPercent/100, 4),
 	})
-
-	return &diskSlice, diskErrors
+	return metricsSlice, diskErrors
 }
 
 // func CollectDiskMetricsTrial() (map[string]disk2.IOCountersStat, error) {

--- a/internal/metric/disk.go
+++ b/internal/metric/disk.go
@@ -4,7 +4,7 @@ import (
 	disk2 "github.com/shirou/gopsutil/v4/disk"
 )
 
-func CollectDiskMetrics() (*[]*DiskData, []string) {
+func CollectDiskMetrics() (*[]*DiskData, []CustomErr) {
 	defaultDiskData := []*DiskData{
 		{
 			ReadSpeedBytes:  nil,
@@ -15,11 +15,15 @@ func CollectDiskMetrics() (*[]*DiskData, []string) {
 		},
 	}
 	var diskData []*DiskData
-	var diskErrors []string
+	var diskErrors []CustomErr
 	diskUsage, diskUsageErr := disk2.Usage("/")
 
 	if diskUsageErr != nil {
-		diskErrors = append(diskErrors, diskUsageErr.Error())
+
+		diskErrors = append(diskErrors, CustomErr{
+			Metric: []string{"disk.usage_percent", "disk.total_bytes", "disk.free_bytes"},
+			Error:  diskUsageErr.Error(),
+		})
 		return &defaultDiskData, diskErrors
 	}
 

--- a/internal/metric/host.go
+++ b/internal/metric/host.go
@@ -6,7 +6,7 @@ import (
 
 func GetHostInformation() (*HostData, []string) {
 	var hostErrors []string
-	defaultHostData := &HostData{
+	defaultHostData := HostData{
 		Os:            "unknown",
 		Platform:      "unknown",
 		KernelVersion: "unknown",
@@ -15,7 +15,7 @@ func GetHostInformation() (*HostData, []string) {
 
 	if infoErr != nil {
 		hostErrors = append(hostErrors, infoErr.Error())
-		return defaultHostData, hostErrors
+		return &defaultHostData, hostErrors
 	}
 
 	return &HostData{

--- a/internal/metric/host.go
+++ b/internal/metric/host.go
@@ -4,8 +4,8 @@ import (
 	"github.com/shirou/gopsutil/v4/host"
 )
 
-func GetHostInformation() (*HostData, []string) {
-	var hostErrors []string
+func GetHostInformation() (*HostData, []CustomErr) {
+	var hostErrors []CustomErr
 	defaultHostData := HostData{
 		Os:            "unknown",
 		Platform:      "unknown",
@@ -14,7 +14,10 @@ func GetHostInformation() (*HostData, []string) {
 	info, infoErr := host.Info()
 
 	if infoErr != nil {
-		hostErrors = append(hostErrors, infoErr.Error())
+		hostErrors = append(hostErrors, CustomErr{
+			Metric: []string{"host.os", "host.platform", "host.kernel_version"},
+			Error:  infoErr.Error(),
+		})
 		return &defaultHostData, hostErrors
 	}
 

--- a/internal/metric/host.go
+++ b/internal/metric/host.go
@@ -4,16 +4,17 @@ import (
 	"github.com/shirou/gopsutil/v4/host"
 )
 
-func GetHostInformation() (*HostData, error) {
+func GetHostInformation() (*HostData, []string) {
+	var hostErrors []string
 	info, infoErr := host.Info()
 
 	if infoErr != nil {
-		return nil, infoErr
+		hostErrors = append(hostErrors, infoErr.Error())
 	}
 
 	return &HostData{
 		Os:            info.OS,
 		Platform:      info.Platform,
 		KernelVersion: info.KernelVersion,
-	}, nil
+	}, hostErrors
 }

--- a/internal/metric/host.go
+++ b/internal/metric/host.go
@@ -6,10 +6,16 @@ import (
 
 func GetHostInformation() (*HostData, []string) {
 	var hostErrors []string
+	defaultHostData := &HostData{
+		Os:            "unknown",
+		Platform:      "unknown",
+		KernelVersion: "unknown",
+	}
 	info, infoErr := host.Info()
 
 	if infoErr != nil {
 		hostErrors = append(hostErrors, infoErr.Error())
+		return defaultHostData, hostErrors
 	}
 
 	return &HostData{

--- a/internal/metric/memory.go
+++ b/internal/metric/memory.go
@@ -4,11 +4,12 @@ import (
 	"github.com/shirou/gopsutil/v4/mem"
 )
 
-func CollectMemoryMetrics() (*MemoryData, error) {
+func CollectMemoryMetrics() (*MemoryData, []string) {
+	var memErrors []string
 	vMem, vMemErr := mem.VirtualMemory()
 
 	if vMemErr != nil {
-		return nil, vMemErr
+		memErrors = append(memErrors, vMemErr.Error())
 	}
 
 	return &MemoryData{
@@ -16,5 +17,5 @@ func CollectMemoryMetrics() (*MemoryData, error) {
 		AvailableBytes: vMem.Available,
 		UsedBytes:      vMem.Used,
 		UsagePercent:   RoundFloatPtr(vMem.UsedPercent/100, 4),
-	}, nil
+	}, memErrors
 }

--- a/internal/metric/memory.go
+++ b/internal/metric/memory.go
@@ -4,8 +4,8 @@ import (
 	"github.com/shirou/gopsutil/v4/mem"
 )
 
-func CollectMemoryMetrics() (*MemoryData, []string) {
-	var memErrors []string
+func CollectMemoryMetrics() (*MemoryData, []CustomErr) {
+	var memErrors []CustomErr
 	defaultMemoryData := &MemoryData{
 		TotalBytes:     0,
 		AvailableBytes: 0,
@@ -15,7 +15,10 @@ func CollectMemoryMetrics() (*MemoryData, []string) {
 	vMem, vMemErr := mem.VirtualMemory()
 
 	if vMemErr != nil {
-		memErrors = append(memErrors, vMemErr.Error())
+		memErrors = append(memErrors, CustomErr{
+			Metric: []string{"memory.total_bytes", "memory.available_bytes", "memory.used_bytes", "memory.usage_percent"},
+			Error:  vMemErr.Error(),
+		})
 		return defaultMemoryData, memErrors
 	}
 

--- a/internal/metric/memory.go
+++ b/internal/metric/memory.go
@@ -6,10 +6,17 @@ import (
 
 func CollectMemoryMetrics() (*MemoryData, []string) {
 	var memErrors []string
+	defaultMemoryData := &MemoryData{
+		TotalBytes:     0,
+		AvailableBytes: 0,
+		UsedBytes:      0,
+		UsagePercent:   RoundFloatPtr(0, 4),
+	}
 	vMem, vMemErr := mem.VirtualMemory()
 
 	if vMemErr != nil {
 		memErrors = append(memErrors, vMemErr.Error())
+		return defaultMemoryData, memErrors
 	}
 
 	return &MemoryData{

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -1,11 +1,20 @@
 package metric
 
 type ApiResponse struct {
-	Cpu    *CpuData     `json:"cpu"`
-	Memory *MemoryData  `json:"memory"`
+	Data   interface{} `json:"data"` // TODO: Update it with a new interface
+	Errors []CustomErr `json:"errors"`
+}
+
+type AllMetrics struct {
+	Cpu    CpuData      `json:"cpu"`
+	Memory MemoryData   `json:"memory"`
 	Disk   *[]*DiskData `json:"disk"`
-	Host   *HostData    `json:"host"`
-	Errors []string     `json:"errors"`
+	Host   HostData     `json:"host"`
+}
+
+type CustomErr struct {
+	Metric []string `json:"metric"`
+	Error  string   `json:"err"`
 }
 
 type CpuData struct {
@@ -45,7 +54,7 @@ func GetAllSystemMetrics() *ApiResponse {
 	disk, diskErr := CollectDiskMetrics()
 	host, hostErr := GetHostInformation()
 
-	var errors []string
+	var errors []CustomErr
 
 	if cpuErr != nil {
 		errors = append(errors, cpuErr...)
@@ -64,10 +73,12 @@ func GetAllSystemMetrics() *ApiResponse {
 	}
 
 	return &ApiResponse{
-		Cpu:    cpu,
-		Memory: memory,
-		Disk:   disk,
-		Host:   host,
+		Data: AllMetrics{
+			Cpu:    *cpu,
+			Memory: *memory,
+			Disk:   disk,
+			Host:   *host,
+		},
 		Errors: errors,
 	}
 }

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -28,13 +28,13 @@ type CustomErr struct {
 }
 
 type CpuData struct {
-	PhysicalCore     int      `json:"physical_core"`     // Physical cores
-	LogicalCore      int      `json:"logical_core"`      // Logical cores aka Threads
-	Frequency        float64  `json:"frequency"`         // Frequency in mHz
-	CurrentFrequency int      `json:"current_frequency"` // Current Frequency in mHz
-	Temperature      *float32 `json:"temperauture"`      // Temperature in Celsius (nil if not available)
-	FreePercent      float64  `json:"free_percent"`      // Free percentage                               //* 1 - (Total - Idle / Total)
-	UsagePercent     float64  `json:"usage_percent"`     // Usage percentage                              //* Total - Idle / Total
+	PhysicalCore     int     `json:"physical_core"`     // Physical cores
+	LogicalCore      int     `json:"logical_core"`      // Logical cores aka Threads
+	Frequency        float64 `json:"frequency"`         // Frequency in mHz
+	CurrentFrequency int     `json:"current_frequency"` // Current Frequency in mHz
+	Temperature      float32 `json:"temperauture"`      // Temperature in Celsius (nil if not available)
+	FreePercent      float64 `json:"free_percent"`      // Free percentage                               //* 1 - (Total - Idle / Total)
+	UsagePercent     float64 `json:"usage_percent"`     // Usage percentage                              //* Total - Idle / Total
 }
 
 func (c CpuData) isMetric() {}

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -1,10 +1,11 @@
 package metric
 
 type ApiResponse struct {
-	Cpu    CpuData     `json:"cpu"`
-	Memory MemoryData  `json:"memory"`
-	Disk   []*DiskData `json:"disk"`
-	Host   HostData    `json:"host"`
+	Cpu    *CpuData     `json:"cpu"`
+	Memory *MemoryData  `json:"memory"`
+	Disk   *[]*DiskData `json:"disk"`
+	Host   *HostData    `json:"host"`
+	Errors []string     `json:"errors"`
 }
 
 type CpuData struct {
@@ -38,7 +39,7 @@ type HostData struct {
 	KernelVersion string `json:"kernel_version"` // Kernel Version
 }
 
-func GetAllSystemMetrics() (*ApiResponse, []string) {
+func GetAllSystemMetrics() *ApiResponse {
 	cpu, cpuErr := CollectCpuMetrics()
 	memory, memErr := CollectMemoryMetrics()
 	disk, diskErr := CollectDiskMetrics()
@@ -63,9 +64,10 @@ func GetAllSystemMetrics() (*ApiResponse, []string) {
 	}
 
 	return &ApiResponse{
-		Cpu:    *cpu,
-		Memory: *memory,
+		Cpu:    cpu,
+		Memory: memory,
 		Disk:   disk,
-		Host:   *host,
-	}, errors
+		Host:   host,
+		Errors: errors,
+	}
 }

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -38,26 +38,28 @@ type HostData struct {
 	KernelVersion string `json:"kernel_version"` // Kernel Version
 }
 
-func GetAllSystemMetrics() (*ApiResponse, error) {
+func GetAllSystemMetrics() (*ApiResponse, []string) {
 	cpu, cpuErr := CollectCpuMetrics()
 	memory, memErr := CollectMemoryMetrics()
 	disk, diskErr := CollectDiskMetrics()
 	host, hostErr := GetHostInformation()
 
+	var errors []string
+
 	if cpuErr != nil {
-		return nil, cpuErr
+		errors = append(errors, cpuErr...)
 	}
 
 	if memErr != nil {
-		return nil, memErr
+		errors = append(errors, memErr...)
 	}
 
 	if diskErr != nil {
-		return nil, diskErr
+		errors = append(errors, diskErr...)
 	}
 
 	if hostErr != nil {
-		return nil, hostErr
+		errors = append(errors, hostErr...)
 	}
 
 	return &ApiResponse{
@@ -65,5 +67,5 @@ func GetAllSystemMetrics() (*ApiResponse, error) {
 		Memory: *memory,
 		Disk:   disk,
 		Host:   *host,
-	}, nil
+	}, errors
 }

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -1,16 +1,26 @@
 package metric
 
+type MetricsSlice []Metric
+
+func (m MetricsSlice) isMetric() {}
+
+type Metric interface {
+	isMetric()
+}
+
 type ApiResponse struct {
-	Data   interface{} `json:"data"` // TODO: Update it with a new interface
+	Data   Metric      `json:"data"` // TODO: Update it with a new interface
 	Errors []CustomErr `json:"errors"`
 }
 
 type AllMetrics struct {
 	Cpu    CpuData      `json:"cpu"`
 	Memory MemoryData   `json:"memory"`
-	Disk   *[]*DiskData `json:"disk"`
+	Disk   MetricsSlice `json:"disk"`
 	Host   HostData     `json:"host"`
 }
+
+func (a AllMetrics) isMetric() {}
 
 type CustomErr struct {
 	Metric []string `json:"metric"`
@@ -27,12 +37,16 @@ type CpuData struct {
 	UsagePercent     float64  `json:"usage_percent"`     // Usage percentage                              //* Total - Idle / Total
 }
 
+func (c CpuData) isMetric() {}
+
 type MemoryData struct {
 	TotalBytes     uint64   `json:"total_bytes"`     // Total space in bytes
 	AvailableBytes uint64   `json:"available_bytes"` // Available space in bytes
 	UsedBytes      uint64   `json:"used_bytes"`      // Used space in bytes      //* Total - Free - Buffers - Cached
 	UsagePercent   *float64 `json:"usage_percent"`   // Usage Percent            //* (Used / Total) * 100.0
 }
+
+func (m MemoryData) isMetric() {}
 
 type DiskData struct {
 	ReadSpeedBytes  *uint64  `json:"read_speed_bytes"`  // TODO: Implement
@@ -42,11 +56,15 @@ type DiskData struct {
 	UsagePercent    *float64 `json:"usage_percent"`     // Usage Percent of "/"
 }
 
+func (d DiskData) isMetric() {}
+
 type HostData struct {
 	Os            string `json:"os"`             // Operating System
 	Platform      string `json:"platform"`       // Platform Name
 	KernelVersion string `json:"kernel_version"` // Kernel Version
 }
+
+func (h HostData) isMetric() {}
 
 func GetAllSystemMetrics() *ApiResponse {
 	cpu, cpuErr := CollectCpuMetrics()

--- a/internal/sysfs/cpu.go
+++ b/internal/sysfs/cpu.go
@@ -5,22 +5,22 @@ import (
 	"strings"
 )
 
-func CpuTemperature() (*float32, error) {
+func CpuTemperature() (float32, error) {
 	temperature, cpuTemperatureError := ShellExec("cat /sys/class/hwmon/hwmon3/temp1_input")
 
 	if cpuTemperatureError != nil {
-		return nil, cpuTemperatureError
+		return 0, cpuTemperatureError
 	}
 
 	temperature = strings.TrimSuffix(temperature, "\n")
 	temp, strConvErr := strconv.Atoi(temperature)
 
 	if strConvErr != nil {
-		return nil, strConvErr
+		return 0, strConvErr
 	}
 
 	var temp_float = float32(temp) / 1000
-	return &temp_float, nil
+	return temp_float, nil
 }
 
 func CpuCurrentFrequency() (int, error) {


### PR DESCRIPTION
This PR allows for individual metrics to fail without aborting the entire metric gathering proccess

- [x] Individual metric modules now return default metrics along with a `[]string` with error messages
- [x] Error message arrays are concatenated when all metrics are requested
- [x] API response returned for all endpoints, `nil` values if that metric not requested  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for CPU, memory, disk, and host metrics, allowing multiple errors to be reported.
	- Introduced a unified `ApiResponse` structure for returning system metrics.
	- Updated `.gitignore` to exclude IDE configuration files and distribution files.

- **Bug Fixes**
	- Improved robustness of metrics collection by accumulating errors instead of terminating on the first error encountered.

- **Documentation**
	- Updated method signatures for various metrics functions to reflect changes in error handling and return types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->