### PR TITLE
Update import paths according to the new go mod name 'github.com/bluewave-labs/bluewave-uptime-agent'

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -10,7 +10,7 @@ test:
 	@go test \
 		-v \
 		-timeout 30s \
-		bluewave-uptime-agent/test
+		github.com/bluewave-labs/bluewave-uptime-agent/test
 
 build:
     @go build -o bwuagent ./cmd/api/

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"bluewave-uptime-agent/internal/config"
-	"bluewave-uptime-agent/internal/handler"
-	"bluewave-uptime-agent/internal/middleware"
 	"log"
 	"net/http"
 	"os"
 
+	"github.com/bluewave-labs/bluewave-uptime-agent/internal/config"
+	"github.com/bluewave-labs/bluewave-uptime-agent/internal/handler"
+	"github.com/bluewave-labs/bluewave-uptime-agent/internal/middleware"
 	"github.com/gin-gonic/gin"
 )
 

--- a/internal/handler/metrics.go
+++ b/internal/handler/metrics.go
@@ -1,8 +1,7 @@
 package handler
 
 import (
-	"bluewave-uptime-agent/internal/metric"
-
+	"github.com/bluewave-labs/bluewave-uptime-agent/internal/metric"
 	"github.com/gin-gonic/gin"
 )
 

--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -1,12 +1,12 @@
 package handler
 
 import (
-	"bluewave-uptime-agent/internal/metric"
 	"encoding/json"
 	"log"
 	"net/http"
 	"time"
 
+	"github.com/bluewave-labs/bluewave-uptime-agent/internal/metric"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 )

--- a/internal/metric/cpu.go
+++ b/internal/metric/cpu.go
@@ -1,8 +1,7 @@
 package metric
 
 import (
-	"bluewave-uptime-agent/internal/sysfs"
-
+	"github.com/bluewave-labs/bluewave-uptime-agent/internal/sysfs"
 	"github.com/shirou/gopsutil/v4/cpu"
 )
 

--- a/test/host_linux_test.go
+++ b/test/host_linux_test.go
@@ -1,12 +1,12 @@
 package test
 
 import (
-	"bluewave-uptime-agent/internal/metric"
-	"bluewave-uptime-agent/internal/sysfs"
 	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/bluewave-labs/bluewave-uptime-agent/internal/metric"
+	"github.com/bluewave-labs/bluewave-uptime-agent/internal/sysfs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,8 +18,8 @@ func TestHostLinux(t *testing.T) {
 	osKernel, osKernelErr := sysfs.ShellExec("uname -r")     // Kernel version
 	info, infoErr := metric.GetHostInformation()
 
-	if infoErr != nil {
-		t.Error(infoErr.Error())
+	if len(infoErr) != 0 {
+		t.Error(infoErr)
 		t.FailNow()
 	}
 


### PR DESCRIPTION
Renaming the module itself causes a build error when I work with the codebase in develop branch. | #15 
`bluewave-uptime-agent` -> `github.com/bluewave-labs/bluewave-uptime-agent`

### Import Path Updates:
Updated the import paths with the new module name because all internal imports are prefixed with the module name. 

### Error Handling Improvement:
* [`test/host_linux_test.go`](diffhunk://#diff-605c6d22605bafa08a782f3ce2a5da4074234374d9bd8596124b0b2a4bcf00d6L21-R22): Modified error handling in the `TestHostLinux` function to check the length of the error string instead of using `infoErr != nil`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error handling in the `TestHostLinux` function for improved clarity and functionality.

- **New Features**
	- Enhanced specificity in test commands by updating paths in the `Justfile`.

- **Documentation**
	- Updated import paths across multiple files to reflect the new module structure, ensuring consistency and accuracy in package references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->