### PR TITLE
Feat/robust cpu temp, resolves #12

### DIFF
--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -28,13 +28,13 @@ type CustomErr struct {
 }
 
 type CpuData struct {
-	PhysicalCore     int     `json:"physical_core"`     // Physical cores
-	LogicalCore      int     `json:"logical_core"`      // Logical cores aka Threads
-	Frequency        float64 `json:"frequency"`         // Frequency in mHz
-	CurrentFrequency int     `json:"current_frequency"` // Current Frequency in mHz
-	Temperature      float32 `json:"temperauture"`      // Temperature in Celsius (nil if not available)
-	FreePercent      float64 `json:"free_percent"`      // Free percentage                               //* 1 - (Total - Idle / Total)
-	UsagePercent     float64 `json:"usage_percent"`     // Usage percentage                              //* Total - Idle / Total
+	PhysicalCore     int       `json:"physical_core"`     // Physical cores
+	LogicalCore      int       `json:"logical_core"`      // Logical cores aka Threads
+	Frequency        float64   `json:"frequency"`         // Frequency in mHz
+	CurrentFrequency int       `json:"current_frequency"` // Current Frequency in mHz
+	Temperature      []float32 `json:"temperature"`       // Temperature in Celsius (nil if not available)
+	FreePercent      float64   `json:"free_percent"`      // Free percentage                               //* 1 - (Total - Idle / Total)
+	UsagePercent     float64   `json:"usage_percent"`     // Usage percentage                              //* Total - Idle / Total
 }
 
 func (c CpuData) isMetric() {}

--- a/internal/sysfs/cpu.go
+++ b/internal/sysfs/cpu.go
@@ -44,7 +44,8 @@ func CpuTemperature() ([]float32, error) {
 			if label, err := os.ReadFile(labelPath); err == nil {
 				labelStr := strings.ToLower(strings.TrimSpace(string(label)))
 				// Only process if it's a core
-				if strings.Contains(labelStr, "core") {
+				// * tctl is the temperature control value for AMD processors. We should also consider it as a core temperature.
+				if strings.Contains(labelStr, "core") || strings.Contains(labelStr, "tctl") {
 					if temp, err := readTempFile(path); err == nil {
 						temps = append(temps, temp)
 					}

--- a/internal/sysfs/cpu.go
+++ b/internal/sysfs/cpu.go
@@ -22,6 +22,20 @@ func readTempFile(path string) (float32, error) {
 	return float32(temp) / 1000, nil
 }
 
+func readCpuFreqFile(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+
+	freq, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, err
+	}
+
+	return freq, nil
+}
+
 func CpuTemperature() ([]float32, error) {
 	// Look in all these folders for core temp
 	corePaths := []string{
@@ -61,19 +75,12 @@ func CpuTemperature() ([]float32, error) {
 }
 
 func CpuCurrentFrequency() (int, error) {
-	frequency, cpuFrequencyError := ShellExec("cat /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq")
+	frequency, cpuFrequencyError := readCpuFreqFile("/sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq")
 
 	if cpuFrequencyError != nil {
 		return 0, cpuFrequencyError
 	}
 
-	frequency = strings.TrimSuffix(frequency, "\n")
-	freq, strConvErr := strconv.Atoi(frequency)
-
-	if strConvErr != nil {
-		return 0, strConvErr
-	}
-
 	// Convert frequency to mHz
-	return freq / 1000, nil
+	return frequency / 1000, nil
 }

--- a/internal/sysfs/cpu.go
+++ b/internal/sysfs/cpu.go
@@ -54,7 +54,10 @@ func CpuTemperature() ([]float32, error) {
 		}
 	}
 
-	return temps, errors.New("unable to read CPU temperature")
+	if len(temps) == 0 {
+		return nil, errors.New("unable to read CPU temperature")
+	}
+	return temps, nil
 }
 
 func CpuCurrentFrequency() (int, error) {

--- a/internal/sysfs/cpu.go
+++ b/internal/sysfs/cpu.go
@@ -1,26 +1,59 @@
 package sysfs
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
 
-func CpuTemperature() (float32, error) {
-	temperature, cpuTemperatureError := ShellExec("cat /sys/class/hwmon/hwmon3/temp1_input")
-
-	if cpuTemperatureError != nil {
-		return 0, cpuTemperatureError
+func readTempFile(path string) (float32, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
 	}
 
-	temperature = strings.TrimSuffix(temperature, "\n")
-	temp, strConvErr := strconv.Atoi(temperature)
-
-	if strConvErr != nil {
-		return 0, strConvErr
+	temp, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, err
 	}
 
-	var temp_float = float32(temp) / 1000
-	return temp_float, nil
+	return float32(temp) / 1000, nil
+}
+
+func CpuTemperature() ([]float32, error) {
+	// Look in all these folders for core temp
+	corePaths := []string{
+		"/sys/devices/platform/coretemp.0/hwmon/hwmon*/temp*_input",
+		"/sys/class/hwmon/hwmon*/temp*_input",
+	}
+
+	var temps []float32
+
+	for _, pathPattern := range corePaths {
+		// Find paths for inputs that may contain core temp
+		matches, err := filepath.Glob(pathPattern)
+		if err != nil { // Keep looking for matches if we get an error
+			continue
+		}
+		// Loop over temp_input paths
+		for _, path := range matches {
+			// Look in the corresponding label to see if this is a core temp
+			labelPath := strings.Replace(path, "_input", "_label", 1)
+			if label, err := os.ReadFile(labelPath); err == nil {
+				labelStr := strings.ToLower(strings.TrimSpace(string(label)))
+				// Only process if it's a core
+				if strings.Contains(labelStr, "core") {
+					if temp, err := readTempFile(path); err == nil {
+						temps = append(temps, temp)
+					}
+				}
+			}
+		}
+	}
+
+	return temps, errors.New("unable to read CPU temperature")
 }
 
 func CpuCurrentFrequency() (int, error) {


### PR DESCRIPTION
This PR implements a more robust method of looking for CPU temps

It iterates over all temp*_input files and then looks for the corresponding label file.  If the label is for a core, it extracts the temp value and adds it to an array of temps.

- [x] Read file from system instead of using shell to `cat`
- [x] Iterate over temp*_input files
  - [x] Extract core temps
- [x] Change return type to []float32
- [x]  Update cpu data type to use []float32

General concept comes from [htop](https://github.com/htop-dev/htop/tree/main) and [lm-sensors](https://github.com/lm-sensors/lm-sensors/blob/master/lib/sysfs.c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced CPU temperature retrieval to support multiple temperature readings from different CPU cores.
	- Introduced a helper function for improved error handling and temperature data processing.

- **Bug Fixes**
	- Improved error handling in the CPU temperature retrieval process, allowing for continued operation despite individual file read errors.

- **Changes**
	- Updated the temperature data structure to accommodate multiple readings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->