### PR TITLE
changed cpuTemp default value on error from 0 to nil as it is now typ…

### DIFF
--- a/internal/metric/cpu.go
+++ b/internal/metric/cpu.go
@@ -72,7 +72,7 @@ func CollectCpuMetrics() (*CpuData, []CustomErr) {
 			Metric: []string{"cpu.temperature"},
 			Error:  cpuTempErr.Error(),
 		})
-		cpuTemp = 0
+		cpuTemp = nil
 	}
 
 	cpuCurrentFrequency, cpuCurFreqErr := sysfs.CpuCurrentFrequency()


### PR DESCRIPTION
Wrong default value was returned, changed value from `0` to `nil`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for CPU temperature data collection, now setting temperature to `nil` instead of `0` when an error occurs, enhancing data interpretation.
- **Chores**
	- Refined the structure of the metric collection process while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->