### PR TITLE
feat(server): Change default port to 59232

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 }
 
 var isPublicApiAllowed bool
-var defaultPort = "3000"
+var defaultPort = "59347"
 
 func NewConfig(port string, apiSecret string, allowPublicApi string) *Config {
 	// Set default port if not provided

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,7 @@ type Config struct {
 }
 
 var isPublicApiAllowed bool
-var defaultPort = "59347"
+var defaultPort = "59232"
 
 func NewConfig(port string, apiSecret string, allowPublicApi string) *Config {
 	// Set default port if not provided


### PR DESCRIPTION
Port 3000 is very popular port for nearly every web applications. We should change the default port to some unique value for avoiding conflicts.