### PR TITLE
Fix Metrics: Add missing RoundFloatPtr function to round float values to 4 digits

### DIFF
--- a/internal/metric/cpu.go
+++ b/internal/metric/cpu.go
@@ -90,7 +90,7 @@ func CollectCpuMetrics() (*CpuData, []CustomErr) {
 		Frequency:        cpuFrequency,
 		CurrentFrequency: cpuCurrentFrequency,
 		Temperature:      cpuTemp,
-		FreePercent:      1 - cpuUsagePercent,
-		UsagePercent:     cpuUsagePercent,
+		FreePercent:      *RoundFloatPtr(1-cpuUsagePercent, 4),
+		UsagePercent:     *RoundFloatPtr(cpuUsagePercent, 4),
 	}, cpuErrors
 }


### PR DESCRIPTION
CPU usage percentages were not rounded to 4 digits. On the cpu metrics added `RoundFloatPtr` function for rounding `FreePercent` and `UsagePercent` values to four decimal places.

Ref: #1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced precision in CPU usage metrics with rounded values for better accuracy.
  
- **Bug Fixes**
	- Improved reporting of CPU metrics through refined calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->